### PR TITLE
Use Shadow path for much better performance

### DIFF
--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -113,6 +113,9 @@
     view.layer.shadowOpacity = 0.8;
     view.layer.shouldRasterize = YES;
     view.layer.rasterizationScale = [[UIScreen mainScreen] scale];
+    UIBezierPath *path = [UIBezierPath bezierPathWithRect:view.bounds];
+    view.layer.shadowPath = path.CGPath;
+
     [UIView animateWithDuration:kSemiModalAnimationDuration animations:^{
       view.frame = f;
     }];

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -111,6 +111,8 @@
     view.layer.shadowOffset = CGSizeMake(0, -2);
     view.layer.shadowRadius = 5.0;
     view.layer.shadowOpacity = 0.8;
+    view.layer.shouldRasterize = YES;
+    view.layer.rasterizationScale = [[UIScreen mainScreen] scale];
     [UIView animateWithDuration:kSemiModalAnimationDuration animations:^{
       view.frame = f;
     }];


### PR DESCRIPTION
After pull request #7, I'm still trying to improve semi modal view's performance.
Especially for the case of a scrolling customized UITableView, the FPS plummeted to around 1~5.

Hence, I added the shadow path for CALayer, which finally makes the UITableView scrolled fluently.
