### PR TITLE
Add ability to set parent view opacity when presenting semi modal view.

### DIFF
--- a/KNSemiModalViewController.podspec
+++ b/KNSemiModalViewController.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name     = 'KNSemiModalViewController'
+  s.version  = '0.1'
+  s.license  = 'MIT'
+  s.summary  = 'UIViewController+KNSemiModal is an effort to make a replica of semi-modal view with pushed-back stacked animation found in the beautiful Park Guides by National Geographic app.'
+  s.homepage = 'https://github.com/kentnguyen/KNSemiModalViewController'
+  s.author   = { 'Kent Nguyen' => 'nguyen.dmz@gmail.com' }
+  s.source   = { :git => 'https://github.com/kentnguyen/KNSemiModalViewController.git', :tag => '0.1' }
+  s.platform = :ios
+  s.source_files = 'Source'
+
+  s.requires_arc = true
+  s.frameworks = 'QuartzCore'
+end

--- a/KNSemiModalViewControllerDemo/KNSecondViewController.m
+++ b/KNSemiModalViewControllerDemo/KNSecondViewController.m
@@ -41,6 +41,10 @@
 #pragma mark - Demo
 
 - (IBAction)buttonDidTouch:(id)sender {
+  
+  // You can set the opacity of the background to whatever you like.
+  // Make sure you do this before you present the view controller.
+  self.parentViewPresentedOpacity = 0.1;
 
   // You can also present a UIViewController with complex views in it
   // and optionally containing an explicit dismiss button for semi modal

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -12,6 +12,11 @@
 #define kSemiModalWasResizedNotification @"kSemiModalWasResizedNotification"
 @interface UIViewController (KNSemiModal)
 
+//  Used to set the opacity of the parent once the SemiModalView appears.
+//  Defaults to 0.5.
+-(CGFloat)parentViewPresentedOpacity;
+-(void)setParentViewPresentedOpacity:(CGFloat)opacity;
+
 -(void)presentSemiViewController:(UIViewController*)vc;
 -(void)presentSemiView:(UIView*)vc;
 -(void)dismissSemiModalView;

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -8,6 +8,10 @@
 
 #import "UIViewController+KNSemiModal.h"
 #import <QuartzCore/QuartzCore.h>
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+#define DEFAULT_PRESENTED_OPACITY 0.5
 
 @interface UIViewController (KNSemiModalInternal)
 -(UIView*)parentTarget;
@@ -62,6 +66,22 @@
 
 @implementation UIViewController (KNSemiModal)
 
+static char PARENT_VIEW_PRESENTED_OPACITY;
+
+-(CGFloat)parentViewPresentedOpacity {
+  NSNumber *_parentViewPresentedOpacity = objc_getAssociatedObject(self, &PARENT_VIEW_PRESENTED_OPACITY);
+  CGFloat result = DEFAULT_PRESENTED_OPACITY;
+  if (_parentViewPresentedOpacity != nil) {
+    result = [_parentViewPresentedOpacity floatValue];
+  }
+  return result;
+}
+
+-(void)setParentViewPresentedOpacity:(CGFloat)opacity {
+  NSNumber *_parentViewPresentedOpacity = [NSNumber numberWithFloat:opacity];
+  objc_setAssociatedObject(self, &PARENT_VIEW_PRESENTED_OPACITY, _parentViewPresentedOpacity, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
 -(void)presentSemiViewController:(UIViewController*)vc {
   [self presentSemiView:vc.view];
 }
@@ -100,7 +120,7 @@
     // Begin overlay animation
     [ss.layer addAnimation:[self animationGroupForward:YES] forKey:@"pushedBackAnimation"];
     [UIView animateWithDuration:kSemiModalAnimationDuration animations:^{
-      ss.alpha = 0.5;
+      ss.alpha = self.parentViewPresentedOpacity; //0.5;
     }];
 
     // Present view animated


### PR DESCRIPTION
When presenting the SemiModalView, it use to fade the parent view to 50% opacity
(fixed). Add methods to set the opacity level which will make it more flexible
for displaying other content in front of the view (e.g. text).

Change is backward compatible (i.e. does not break existing code) and requires
user to set property on view. Implemented using objective-c runtime set/get
Associative Object Behaviors on the view controller instance.
