### PR TITLE
Configurable parameters: animation duration, parent alpha, optional push-back, shadow opacity

### DIFF
--- a/KNSemiModalViewControllerDemo/KNSecondViewController.m
+++ b/KNSemiModalViewControllerDemo/KNSecondViewController.m
@@ -46,7 +46,8 @@
   // and optionally containing an explicit dismiss button for semi modal
   [self presentSemiViewController:semiVC withOptions:@{
 		 KNSemiModalOptionKeys.pushParentBack : @(YES),
-		 KNSemiModalOptionKeys.animationDuration : @(2.0)
+		 KNSemiModalOptionKeys.animationDuration : @(2.0),
+		 KNSemiModalOptionKeys.shadowOpacity : @(0.3),
 	 }];
 
 }

--- a/KNSemiModalViewControllerDemo/KNSecondViewController.m
+++ b/KNSemiModalViewControllerDemo/KNSecondViewController.m
@@ -44,7 +44,7 @@
 
   // You can also present a UIViewController with complex views in it
   // and optionally containing an explicit dismiss button for semi modal
-  [self presentSemiViewController:semiVC];
+  [self presentSemiViewController:semiVC withOptions:@{ KNSemiModalOptionKeys.pushParentBack : @(YES) }];
 
 }
 

--- a/KNSemiModalViewControllerDemo/KNSecondViewController.m
+++ b/KNSemiModalViewControllerDemo/KNSecondViewController.m
@@ -44,7 +44,10 @@
 
   // You can also present a UIViewController with complex views in it
   // and optionally containing an explicit dismiss button for semi modal
-  [self presentSemiViewController:semiVC withOptions:@{ KNSemiModalOptionKeys.pushParentBack : @(YES) }];
+  [self presentSemiViewController:semiVC withOptions:@{
+		 KNSemiModalOptionKeys.pushParentBack : @(YES),
+		 KNSemiModalOptionKeys.animationDuration : @(2.0)
+	 }];
 
 }
 

--- a/KNSemiModalViewControllerDemo/KNTableDemoController.m
+++ b/KNSemiModalViewControllerDemo/KNTableDemoController.m
@@ -48,7 +48,7 @@
   [tableView deselectRowAtIndexPath:indexPath animated:NO];
 
   // You have to retain the ownership of ViewController that you are presenting
-  [self presentSemiViewController:modalVC];
+  [self presentSemiViewController:modalVC withOptions:@{ KNSemiModalOptionKeys.pushParentBack : @(NO) }];
   
   // The following code won't work
 //  KNModalTableViewController * vc = [[KNModalTableViewController alloc] initWithStyle:UITableViewStylePlain];

--- a/KNSemiModalViewControllerDemo/KNTableDemoController.m
+++ b/KNSemiModalViewControllerDemo/KNTableDemoController.m
@@ -48,7 +48,10 @@
   [tableView deselectRowAtIndexPath:indexPath animated:NO];
 
   // You have to retain the ownership of ViewController that you are presenting
-  [self presentSemiViewController:modalVC withOptions:@{ KNSemiModalOptionKeys.pushParentBack : @(NO) }];
+  [self presentSemiViewController:modalVC withOptions:@{
+		 KNSemiModalOptionKeys.pushParentBack : @(NO),
+		 KNSemiModalOptionKeys.parentAlpha : @(0.8)
+	 }];
   
   // The following code won't work
 //  KNModalTableViewController * vc = [[KNModalTableViewController alloc] initWithStyle:UITableViewStylePlain];

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+This fork lets code clients configure parameters through an `options` dictionary.
+
+Currently supports configuring the following:
+
+- animation duration
+- parent alpha
+- optional push-back
+- shadow opacity
+
+Easily extend this to anything you would want to make configurable. Feel free to submit pull requests.
+
+Twitter: [@yangmeyer](http://twitter.com/yangmeyer)  
+App.net: [@yangmeyer](https://alpha.app.net/yangmeyer)  
+[hello@yangmeyer.de](mailto:hello@yangmeyer.de)
+
+---------
+
 ## UIViewController+KNSemiModal Category
 
 UIViewController+KNSemiModal is an effort to make a replica of **semi-modal view with pushed-back stacked animation** found in the beautiful [Park Guides by National Geographic](http://itunes.apple.com/us/app/national-parks-by-national/id518426085?mt=8) app. You can see this original semi-modal view below.

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -10,7 +10,15 @@
 #define kSemiModalDidShowNotification @"kSemiModalDidShowNotification"
 #define kSemiModalDidHideNotification @"kSemiModalDidHideNotification"
 #define kSemiModalWasResizedNotification @"kSemiModalWasResizedNotification"
+
+extern const struct KNSemiModalOptionKeys {
+	__unsafe_unretained NSString *pushParentBack;		 // boxed BOOL. default is YES.
+} KNSemiModalOptionKeys;
+
 @interface UIViewController (KNSemiModal)
+
+-(void)presentSemiViewController:(UIViewController*)vc withOptions:(NSDictionary*)options;
+-(void)presentSemiView:(UIView*)view withOptions:(NSDictionary*)options;
 
 -(void)presentSemiViewController:(UIViewController*)vc;
 -(void)presentSemiView:(UIView*)vc;

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -13,6 +13,8 @@
 extern const struct KNSemiModalOptionKeys {
 	__unsafe_unretained NSString *animationDuration; // boxed double, in seconds. default is 0.5.
 	__unsafe_unretained NSString *pushParentBack;		 // boxed BOOL. default is YES.
+	__unsafe_unretained NSString *parentAlpha;       // boxed float. lower is darker. default is 0.5.
+
 } KNSemiModalOptionKeys;
 
 @interface UIViewController (KNSemiModal)

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -6,12 +6,12 @@
 //  Copyright (c) 2012 Kent Nguyen. All rights reserved.
 //
 
-#define kSemiModalAnimationDuration   0.5
 #define kSemiModalDidShowNotification @"kSemiModalDidShowNotification"
 #define kSemiModalDidHideNotification @"kSemiModalDidHideNotification"
 #define kSemiModalWasResizedNotification @"kSemiModalWasResizedNotification"
 
 extern const struct KNSemiModalOptionKeys {
+	__unsafe_unretained NSString *animationDuration; // boxed double, in seconds. default is 0.5.
 	__unsafe_unretained NSString *pushParentBack;		 // boxed BOOL. default is YES.
 } KNSemiModalOptionKeys;
 

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -28,6 +28,8 @@ extern const struct KNSemiModalOptionKeys {
 -(void)dismissSemiModalView;
 -(void)resizeSemiView:(CGSize)newSize;
 
+-(void)dismissSemiModalViewWithCompletion:(void (^)(void))completion;
+
 @end
 
 // Convenient category method to find actual ViewController that contains a view

--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -14,6 +14,7 @@ extern const struct KNSemiModalOptionKeys {
 	__unsafe_unretained NSString *animationDuration; // boxed double, in seconds. default is 0.5.
 	__unsafe_unretained NSString *pushParentBack;		 // boxed BOOL. default is YES.
 	__unsafe_unretained NSString *parentAlpha;       // boxed float. lower is darker. default is 0.5.
+	__unsafe_unretained NSString *shadowOpacity;     // default is 0.8
 
 } KNSemiModalOptionKeys;
 

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -118,7 +118,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 		
     // Calulate all frames
     CGRect sf = view.frame;
-    CGRect vf = target.frame;
+    CGRect vf = target.bounds;
     CGRect f  = CGRectMake(0, vf.size.height-sf.size.height, vf.size.width, sf.size.height);
     CGRect of = CGRectMake(0, 0, vf.size.width, vf.size.height-sf.size.height);
 

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -14,6 +14,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 	.animationDuration = @"KNSemiModalOptionAnimationDuration",
 	.pushParentBack = @"KNSemiModalOptionPushParentBack",
 	.parentAlpha = @"KNSemiModalOptionParentAlpha",
+	.shadowOpacity = @"KNSemiModalOptionShadowOpacity",
 };
 
 #define kSemiModalTransitionOptions @"kn_semiModalTransitionOptions"
@@ -42,6 +43,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 		KNSemiModalOptionKeys.animationDuration : @(0.5),
 		KNSemiModalOptionKeys.parentAlpha : @(0.5),
 		KNSemiModalOptionKeys.pushParentBack : @(YES),
+		KNSemiModalOptionKeys.shadowOpacity : @(0.8),
 	};
 	objc_setAssociatedObject(self, kSemiModalTransitionDefaults, defaults, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
@@ -155,7 +157,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
     view.layer.shadowColor = [[UIColor blackColor] CGColor];
     view.layer.shadowOffset = CGSizeMake(0, -2);
     view.layer.shadowRadius = 5.0;
-    view.layer.shadowOpacity = 0.2;
+    view.layer.shadowOpacity = [[self kn_optionsOrDefaultForKey:KNSemiModalOptionKeys.shadowOpacity] floatValue];
     view.layer.shouldRasterize = YES;
     view.layer.rasterizationScale = [[UIScreen mainScreen] scale];
     UIBezierPath *path = [UIBezierPath bezierPathWithRect:view.bounds];

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -175,6 +175,10 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 }
 
 -(void)dismissSemiModalView {
+	[self dismissSemiModalViewWithCompletion:nil];
+}
+
+-(void)dismissSemiModalViewWithCompletion:(void (^)(void))completion {
   UIView * target = [self parentTarget];
   UIView * modal = [target.subviews objectAtIndex:target.subviews.count-1];
   UIView * overlay = [target.subviews objectAtIndex:target.subviews.count-2];
@@ -197,6 +201,9 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
     if(finished){
       [[NSNotificationCenter defaultCenter] postNotificationName:kSemiModalDidHideNotification
                                                           object:self];
+		if (completion) {
+			completion();
+		}
     }
   }];
 }

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -13,10 +13,12 @@
 const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 	.animationDuration = @"KNSemiModalOptionAnimationDuration",
 	.pushParentBack = @"KNSemiModalOptionPushParentBack",
+	.parentAlpha = @"KNSemiModalOptionParentAlpha",
 };
 
 #define kSemiModalTransitionOptions @"kn_semiModalTransitionOptions"
 #define kSemiModalDefaultAnimationDuration 0.5
+#define kSemiModalDefaultOverlayAlpha 0.5
 
 @interface UIViewController (KNSemiModalInternal)
 -(UIView*)parentTarget;
@@ -49,6 +51,12 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 	} else {
 		return [[options objectForKey:KNSemiModalOptionKeys.pushParentBack] boolValue];
 	}
+}
+
+-(CGFloat)kn_optionsParentAlphaOrDefault {
+	NSDictionary *options = objc_getAssociatedObject(self, kSemiModalTransitionOptions);
+	return [([options objectForKey:KNSemiModalOptionKeys.parentAlpha]
+					 ?: @(kSemiModalDefaultOverlayAlpha)) floatValue];
 }
 
 -(CAAnimationGroup*)animationGroupForward:(BOOL)_forward {
@@ -141,7 +149,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 		}
 		NSTimeInterval duration = [self kn_optionsDurationOrDefault];
     [UIView animateWithDuration:duration animations:^{
-      ss.alpha = 0.5;
+      ss.alpha = [self kn_optionsParentAlphaOrDefault];
     }];
 
     // Present view animated


### PR DESCRIPTION
Lets code clients configure parameters through an options dictionary.

Currently supports configuring the following:
- animation duration
- parent alpha
- optional push-back
- shadow opacity

Easily extend this to anything you would want to make configurable.
