### PR TITLE
presentViewController / presentModalViewController like retaining style and disable the default cancel behavior if the user taps outside of the presenting SemiModalView

### DIFF
--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -15,6 +15,7 @@ extern const struct KNSemiModalOptionKeys {
 	__unsafe_unretained NSString *pushParentBack;		 // boxed BOOL. default is YES.
 	__unsafe_unretained NSString *parentAlpha;       // boxed float. lower is darker. default is 0.5.
 	__unsafe_unretained NSString *shadowOpacity;     // default is 0.8
+    __unsafe_unretained NSString *disableCancel;    // boxed BOOL. default is NO.
 
 } KNSemiModalOptionKeys;
 

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -15,6 +15,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 	.pushParentBack = @"KNSemiModalOptionPushParentBack",
 	.parentAlpha = @"KNSemiModalOptionParentAlpha",
 	.shadowOpacity = @"KNSemiModalOptionShadowOpacity",
+    .disableCancel = @"KNSemiModalOptionDisableCancel",
 };
 
 static const uint kScreenshotTag = 10;
@@ -47,6 +48,7 @@ static const uint kDismissButtonTag = 12;
 		KNSemiModalOptionKeys.parentAlpha : @(0.5),
 		KNSemiModalOptionKeys.pushParentBack : @(YES),
 		KNSemiModalOptionKeys.shadowOpacity : @(0.8),
+        KNSemiModalOptionKeys.disableCancel : @(NO),
 	};
 	objc_setAssociatedObject(self, kSemiModalTransitionDefaults, defaults, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
@@ -139,15 +141,19 @@ static const uint kDismissButtonTag = 12;
     [overlay addSubview:ss];
     [target addSubview:overlay];
 
-    // Dismiss button
-    // Don't use UITapGestureRecognizer to avoid complex handling
-    UIButton * dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    [dismissButton addTarget:self action:@selector(dismissSemiModalView) forControlEvents:UIControlEventTouchUpInside];
-    dismissButton.backgroundColor = [UIColor clearColor];
-    dismissButton.frame = of;
-    dismissButton.tag = kDismissButtonTag;
-    [overlay addSubview:dismissButton];
-
+    if(![[self kn_optionsOrDefaultForKey:KNSemiModalOptionKeys.disableCancel] boolValue])
+    {
+        // Dismiss button
+        // Don't use UITapGestureRecognizer to avoid complex handling
+        UIButton * dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
+        [dismissButton addTarget:self action:@selector(dismissSemiModalView) forControlEvents:UIControlEventTouchUpInside];
+        dismissButton.backgroundColor = [UIColor clearColor];
+        dismissButton.frame = of;
+        dismissButton.tag = kDismissButtonTag;
+        [overlay addSubview:dismissButton];
+    }
+        
+        
     // Begin overlay animation
 		if ([[self kn_optionsOrDefaultForKey:KNSemiModalOptionKeys.pushParentBack] boolValue]) {
 			[ss.layer addAnimation:[self animationGroupForward:YES] forKey:@"pushedBackAnimation"];

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -107,7 +107,8 @@ static const uint kDismissButtonTag = 12;
 }
 
 -(void)presentSemiViewController:(UIViewController*)vc withOptions:(NSDictionary*)options {
-  [self presentSemiView:vc.view withOptions:options];
+    objc_setAssociatedObject(self, @"presentViewController", vc, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    [self presentSemiView:vc.view withOptions:options];
 }
 
 -(void)presentSemiView:(UIView*)view withOptions:(NSDictionary*)options {
@@ -206,6 +207,7 @@ static const uint kDismissButtonTag = 12;
     if(finished){
       [[NSNotificationCenter defaultCenter] postNotificationName:kSemiModalDidHideNotification
                                                           object:self];
+        objc_removeAssociatedObjects(self);
 		if (completion) {
 			completion();
 		}


### PR DESCRIPTION
I have added the ability to keep track of the ViewControllers like presentViewController and presentModalViewController. So you don't have to add a iVar or property to the presenting ViewController.

It is also requested in https://github.com/kentnguyen/KNSemiModalViewController/issues/23 and https://github.com/kentnguyen/KNSemiModalViewController/pull/19
