### PR TITLE
End image context after capturing screenshot

### DIFF
--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -126,6 +126,7 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
 	UIGraphicsBeginImageContextWithOptions(target.bounds.size, YES, [[UIScreen mainScreen] scale]);
     [target.layer renderInContext:UIGraphicsGetCurrentContext()];
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
 	screenshotContainer.hidden = NO;
 	semiView.hidden = NO;
 	


### PR DESCRIPTION
Image context was opened but not ended on capturing screenshot. This fixes it.
