### PR TITLE
Send a willDismissSemiModalView message if self responds to it

### DIFF
--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -305,6 +305,8 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
     [self kn_addOrUpdateParentScreenshotInView:overlay];
 }
 -(void)dismissSemiModalView {
+    if ([self respondsToSelector:@selector(willDismissSemiModalView)])
+        [self performSelectorOnMainThread:@selector(willDismissSemiModalView) withObject:nil waitUntilDone:YES];
 	[self dismissSemiModalViewWithCompletion:nil];
 }
 

--- a/Source/UIViewController+KNSemiModal.m
+++ b/Source/UIViewController+KNSemiModal.m
@@ -305,8 +305,9 @@ const struct KNSemiModalOptionKeys KNSemiModalOptionKeys = {
     [self kn_addOrUpdateParentScreenshotInView:overlay];
 }
 -(void)dismissSemiModalView {
-    if ([self respondsToSelector:@selector(willDismissSemiModalView)])
-        [self performSelectorOnMainThread:@selector(willDismissSemiModalView) withObject:nil waitUntilDone:YES];
+    SEL willDismissSelector = NSSelectorFromString(@"willDismissSemiModalView");
+    if ([self respondsToSelector:willDismissSelector])
+        [self performSelectorOnMainThread:willDismissSelector withObject:nil waitUntilDone:YES];
 	[self dismissSemiModalViewWithCompletion:nil];
 }
 


### PR DESCRIPTION
Allows for cleanup or other work to be done when view is dismissed by a tap in the top area. For instance, if you want to do status bar style changes upon display, but want to change back the status bar after dismissal. The transparent UIButton doesn't give the calling code the opportunity to do any updates, unlike when programmatically dismissing the semi-modal.

Other alternatives: a KNSemiModalOptionKey for the block, or using NSNotificationCenter. This seemed simpler than an option key, and I feel it's better than a notification because it's more like UIKit's messaging. And since it's a category, setting a delegate with objc_setAssociatedObject with making self the delegate of self seemed weird.
