### PR TITLE
Use NS_ENUM with typedef 

### DIFF
--- a/Source/UIViewController+KNSemiModal.h
+++ b/Source/UIViewController+KNSemiModal.h
@@ -45,7 +45,7 @@ extern const struct KNSemiModalOptionKeys {
     __unsafe_unretained NSString *backgroundView;     // UIView, custom background.
 } KNSemiModalOptionKeys;
 
-NS_ENUM(NSUInteger, KNSemiModalTransitionStyle) {
+typedef NS_ENUM(NSUInteger, KNSemiModalTransitionStyle) {
 	KNSemiModalTransitionStyleSlideUp,
 	KNSemiModalTransitionStyleFadeInOut,
 	KNSemiModalTransitionStyleFadeIn,


### PR DESCRIPTION
Without typedef will cause duplicate symbol error if multiple import UIViewController+KNSemiModal.h in static library project. I don't know why. But add typedef at before of NS_ENUM will be work.
